### PR TITLE
Add GitHub Pages deployment setup

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,60 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'website/**'
+      - '.github/workflows/deploy.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v4
+
+      - name: Install dependencies
+        run: cd website && npm ci
+
+      - name: Build website
+        run: cd website && npm run build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./website/build
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/work-logs/2025-08-18-github-pages-deployment-setup.md
+++ b/docs/work-logs/2025-08-18-github-pages-deployment-setup.md
@@ -1,0 +1,58 @@
+# 2025-08-18: GitHub Pages 자동 배포 설정
+
+## 📋 오늘의 목표
+Docusaurus 웹사이트를 GitHub Pages로 자동 배포하여 다른 사람들이 실제로 접근할 수 있는 공개 튜토리얼 사이트 완성
+
+## 🎯 프로젝트 현황
+- **이전 단계**: Docusaurus 웹사이트 구축 완료 (2025-08-17)
+- **현재 목표**: 공개 배포 및 자동화 파이프라인 구축
+- **최종 목표**: 누구나 접근 가능한 실용적 LLM 튜토리얼 사이트
+
+## 🌐 배포 전략: GitHub Pages
+
+### 선택 이유
+- **무료**: GitHub과 완벽 통합
+- **자동화**: main 브랜치 푸시 시 자동 배포
+- **독립성**: 기존 hunhoon21.github.io 블로그와 분리
+
+### 도메인 구조
+```
+기존: hunhoon21.github.io (개인 블로그)
+신규: hunhoon21.github.io/llm-inference-lab/ (LLM 튜토리얼)
+```
+
+## 🔧 GitHub Actions 워크플로우
+
+### 핵심 설정
+- **트리거**: main 브랜치의 website/ 폴더 변경 시
+- **Node.js**: v18, npm 캐싱 활성화
+- **빌드**: website 폴더에서 npm ci → npm run build
+- **배포**: GitHub Pages에 자동 배포
+
+### 효율성 최적화
+- 필요한 경우에만 배포 (paths 필터)
+- npm 의존성 캐싱으로 빌드 시간 단축
+- 적절한 권한 설정
+
+## 📋 배포 활성화 방법
+
+1. **PR 머지 후 GitHub 설정**
+   - Settings → Pages → Source: "GitHub Actions" 선택
+
+2. **자동 배포 확인**
+   - Actions 탭에서 배포 상태 모니터링
+   - 3-5분 후 https://hunhoon21.github.io/llm-inference-lab/ 접속
+
+## 📝 오늘의 성과
+- [x] GitHub Pages 배포 워크플로우 설계
+- [x] 효율적인 트리거 및 캐싱 설정
+- [x] 2025-08-18 워크로그 작성
+- [x] PR 생성 준비
+
+## 🔄 다음 단계
+- PR 머지 및 GitHub Pages 활성화
+- 실제 배포 테스트 및 접근성 확인
+
+---
+
+**결론**: 개발 환경에서 전 세계 접근 가능한 튜토리얼 사이트로 완전히 전환 준비 완료!


### PR DESCRIPTION
## Summary
- Setup automated GitHub Actions workflow for GitHub Pages deployment
- Add comprehensive 2025-08-18 worklog documenting deployment strategy
- Configure efficient deployment triggers and caching for optimal performance
- Ready to activate public access at hunhoon21.github.io/llm-inference-lab/

## Key Features
### 🚀 Automated Deployment
- **Smart Triggers**: Only deploy when website/ folder changes
- **Fast Builds**: npm caching reduces build time
- **Proper Permissions**: Secure OIDC token-based authentication

### 📋 Deployment Process  
1. Merge this PR
2. Go to Settings → Pages → Select "GitHub Actions" as source
3. Automatic deployment on future main branch pushes
4. Site will be live at https://hunhoon21.github.io/llm-inference-lab/

### 🎯 Independent Operation
- Works alongside existing hunhoon21.github.io blog
- Completely separate subdirectory (/llm-inference-lab/)
- No conflicts with existing GitHub Pages setup

## Test Plan
- [x] GitHub Actions workflow syntax validated
- [x] Deployment path configuration verified  
- [x] Node.js and npm setup tested locally
- [x] Build process confirmed working
- [x] Ready for GitHub Pages activation

🤖 Generated with [Claude Code](https://claude.ai/code)